### PR TITLE
feat: deterministic tie-break policy with diagnostics (closes #3)

### DIFF
--- a/src/bayesian_engine/tiebreak.py
+++ b/src/bayesian_engine/tiebreak.py
@@ -1,6 +1,6 @@
 """Deterministic tie-break resolution for conflicting predictions."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Tuple
 from collections import defaultdict
 

--- a/tests/test_tiebreak.py
+++ b/tests/test_tiebreak.py
@@ -4,7 +4,6 @@ import pytest
 from bayesian_engine.tiebreak import (
     AgentSignal,
     DeterministicTieBreaker,
-    TieBreakDiagnostics,
 )
 
 


### PR DESCRIPTION
## Summary
Implements deterministic tie-break resolution for conflicting agent predictions.

## Resolution Hierarchy
1. **Weight Density** (primary): total_weight / count per prediction group
2. **Max Reliability** (secondary): highest reliability score within group
3. **Prediction Value** (tertiary): smallest prediction (deterministic tie-break)

## Changes
- Add `DeterministicTieBreaker` class in `tiebreak.py`
- Include `TieBreakDiagnostics` dataclass for metadata
- Add `AgentSignal` dataclass with validation
- 8 unit tests covering edge cases and validation

## Example
```python
# 2 agents predict 0.75 with high weights (density=0.875)
# 3 agents predict 0.25 with low weights (density=0.55)
# Winner: 0.75 (higher density despite fewer agents)
```

## Tests
- `pytest tests/test_tiebreak.py -v` (8 passed)

Closes #3