### PR TITLE
feat: SQLite reliability persistence (issue #10)

### DIFF
--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -1,0 +1,157 @@
+# Reliability Persistence — SQLite Store
+
+## Overview
+
+The reliability module (`src/bayesian_engine/reliability.py`) provides
+persistent, per-source, per-market reliability scores backed by SQLite.
+These scores feed into the Bayesian consensus computation to weight each
+source's contribution.
+
+## Database Schema
+
+A single SQLite database file stores the `sources` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS sources (
+    source_id   TEXT    NOT NULL,
+    market_id   TEXT    NOT NULL,
+    reliability REAL    NOT NULL DEFAULT 0.5,
+    confidence  REAL    NOT NULL DEFAULT 0.5,
+    updated_at  TEXT    NOT NULL,
+    PRIMARY KEY (source_id, market_id)
+);
+```
+
+| Column        | Type  | Description                                        |
+|---------------|-------|----------------------------------------------------|
+| `source_id`   | TEXT  | Unique identifier for the prediction source/agent  |
+| `market_id`   | TEXT  | Market or question the prediction applies to       |
+| `reliability` | REAL  | Reliability score in \[0, 1\]                      |
+| `confidence`  | REAL  | Confidence in the reliability estimate in \[0, 1\] |
+| `updated_at`  | TEXT  | ISO-8601 UTC timestamp of last update              |
+
+The primary key is the composite `(source_id, market_id)`, so each source
+has an independent reliability score per market.
+
+## Cold-Start Defaults
+
+When a source has no stored record, the store returns:
+
+| Field         | Default |
+|---------------|---------|
+| `reliability` |   0.50  |
+| `confidence`  |   0.50  |
+
+Cold-start lookups do **not** create database rows; a record is only
+persisted after the first `update_reliability()` call.
+
+## API
+
+### `SQLiteReliabilityStore(db_path)`
+
+Constructor.  Pass a file path for persistent storage or `":memory:"` for
+an ephemeral in-memory database (useful in tests).
+
+The store can also be used as a context manager:
+
+```python
+with SQLiteReliabilityStore("data/reliability.db") as store:
+    rec = store.get_reliability("agent-a", "market-1")
+```
+
+---
+
+### `get_reliability(source_id, market_id) → ReliabilityRecord`
+
+Retrieve the reliability record for a source in a market.
+
+Returns cold-start defaults if the source has never been recorded.
+
+```python
+rec = store.get_reliability("agent-a", "market-1")
+print(rec.reliability)  # 0.5 if unseen
+```
+
+---
+
+### `update_reliability(source_id, market_id, outcome_correct: bool) → ReliabilityRecord`
+
+Apply a post-outcome Bayesian-style update.
+
+- `outcome_correct=True` → reliability **increases** (source was right)
+- `outcome_correct=False` → reliability **decreases** (source was wrong)
+
+**Constraints:**
+
+| Parameter       | Value | Description                                 |
+|-----------------|-------|---------------------------------------------|
+| `MAX_UPDATE_STEP` | 0.10 | Absolute cap on reliability change per call |
+
+The reliability value is always clamped to \[0, 1\].
+
+Confidence increases with every update (closing 10 % of the gap to 1.0
+each time), reflecting that more evidence has been observed.
+
+```python
+rec = store.update_reliability("agent-a", "market-1", outcome_correct=True)
+print(rec.reliability)  # > 0.5
+```
+
+---
+
+### `list_sources(market_id=None) → list[ReliabilityRecord]`
+
+List all stored records, optionally filtered by market.  Results are
+sorted by `source_id` (and then `market_id` when unfiltered).
+
+```python
+all_sources = store.list_sources()
+market_sources = store.list_sources(market_id="market-1")
+```
+
+---
+
+### `close()`
+
+Close the underlying SQLite connection.  Also called automatically when
+the store is used as a context manager.
+
+## Data Model
+
+### `ReliabilityRecord` (frozen dataclass)
+
+| Field         | Type  | Description                               |
+|---------------|-------|-------------------------------------------|
+| `source_id`   | str   | Source identifier                         |
+| `market_id`   | str   | Market identifier                         |
+| `reliability` | float | Current reliability score                 |
+| `confidence`  | float | Confidence in the reliability estimate    |
+| `updated_at`  | str   | ISO-8601 UTC timestamp (empty for unseen) |
+
+## Integration with Consensus Engine
+
+The `compute_consensus()` function in `core.py` accepts an optional
+`source_reliability` dict.  To integrate the reliability store:
+
+```python
+from bayesian_engine.core import compute_consensus
+from bayesian_engine.reliability import SQLiteReliabilityStore
+
+store = SQLiteReliabilityStore("data/reliability.db")
+
+signals = [
+    {"sourceId": "agent-a", "probability": 0.7},
+    {"sourceId": "agent-b", "probability": 0.4},
+]
+
+# Build reliability dict from store
+source_reliability = {}
+for sig in signals:
+    rec = store.get_reliability(sig["sourceId"], "market-1")
+    source_reliability[sig["sourceId"]] = {
+        "reliability": rec.reliability,
+        "confidence": rec.confidence,
+    }
+
+result = compute_consensus(signals, source_reliability=source_reliability)
+```

--- a/src/bayesian_engine/reliability.py
+++ b/src/bayesian_engine/reliability.py
@@ -1,1 +1,222 @@
-"""Reliability storage and update logic (SQLite)."""
+"""Reliability storage and update logic (SQLite).
+
+Provides persistent storage for source reliability scores and confidence
+values. Supports Bayesian-style post-outcome updates with a capped update
+step to prevent wild swings from a single outcome.
+
+Cold-start defaults (PRD §reliability):
+    reliability = 0.50
+    confidence  = 0.50
+
+Max update step per outcome: 0.10
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Union
+
+# Cold-start defaults (PRD)
+DEFAULT_RELIABILITY: float = 0.50
+DEFAULT_CONFIDENCE: float = 0.50
+
+# Maximum change in reliability per single outcome (PRD)
+MAX_UPDATE_STEP: float = 0.10
+
+# Learning rate applied before capping
+_BASE_LEARNING_RATE: float = 0.15
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS sources (
+    source_id   TEXT    NOT NULL,
+    market_id   TEXT    NOT NULL,
+    reliability REAL    NOT NULL DEFAULT 0.5,
+    confidence  REAL    NOT NULL DEFAULT 0.5,
+    updated_at  TEXT    NOT NULL,
+    PRIMARY KEY (source_id, market_id)
+);
+"""
+
+
+@dataclass(frozen=True)
+class ReliabilityRecord:
+    """Immutable snapshot of a source's reliability data."""
+
+    source_id: str
+    market_id: str
+    reliability: float
+    confidence: float
+    updated_at: str
+
+
+class SQLiteReliabilityStore:
+    """SQLite-backed store for per-source, per-market reliability scores.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.  Use ``":memory:"`` for an
+        ephemeral in-memory database (useful in tests).
+    """
+
+    def __init__(self, db_path: Union[str, Path] = ":memory:") -> None:
+        self._db_path = str(db_path)
+        self._conn: sqlite3.Connection = sqlite3.connect(
+            self._db_path,
+            # Enable WAL for better concurrent-read performance
+            isolation_level=None,
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_reliability(
+        self,
+        source_id: str,
+        market_id: str,
+    ) -> ReliabilityRecord:
+        """Return the reliability record for *source_id* in *market_id*.
+
+        If no record exists (cold-start), returns a record populated with
+        the PRD default values (reliability=0.5, confidence=0.5).
+        """
+        row = self._conn.execute(
+            "SELECT source_id, market_id, reliability, confidence, updated_at "
+            "FROM sources WHERE source_id = ? AND market_id = ?",
+            (source_id, market_id),
+        ).fetchone()
+
+        if row is not None:
+            return ReliabilityRecord(
+                source_id=row["source_id"],
+                market_id=row["market_id"],
+                reliability=row["reliability"],
+                confidence=row["confidence"],
+                updated_at=row["updated_at"],
+            )
+
+        # Cold-start: return defaults without persisting
+        return ReliabilityRecord(
+            source_id=source_id,
+            market_id=market_id,
+            reliability=DEFAULT_RELIABILITY,
+            confidence=DEFAULT_CONFIDENCE,
+            updated_at="",
+        )
+
+    def update_reliability(
+        self,
+        source_id: str,
+        market_id: str,
+        outcome_correct: bool,
+    ) -> ReliabilityRecord:
+        """Apply a Bayesian-style reliability update after an outcome.
+
+        The update direction depends on *outcome_correct*:
+        - ``True``  → reliability moves **up** (source was right)
+        - ``False`` → reliability moves **down** (source was wrong)
+
+        The raw delta is ``_BASE_LEARNING_RATE * direction`` and is then
+        clamped so the absolute change never exceeds ``MAX_UPDATE_STEP``.
+        The final value is clamped to [0, 1].
+
+        Confidence grows toward 1.0 with every update (the store has seen
+        more evidence about this source).
+
+        Returns the updated :class:`ReliabilityRecord`.
+        """
+        current = self.get_reliability(source_id, market_id)
+
+        direction = 1.0 if outcome_correct else -1.0
+        raw_delta = _BASE_LEARNING_RATE * direction
+
+        # Cap the absolute step
+        capped_delta = max(-MAX_UPDATE_STEP, min(MAX_UPDATE_STEP, raw_delta))
+
+        new_reliability = max(0.0, min(1.0, current.reliability + capped_delta))
+
+        # Confidence grows toward 1.0; each update closes 10% of the gap
+        new_confidence = current.confidence + (1.0 - current.confidence) * 0.10
+        new_confidence = min(1.0, new_confidence)
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        self._conn.execute(
+            """
+            INSERT INTO sources (source_id, market_id, reliability, confidence, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(source_id, market_id)
+            DO UPDATE SET reliability = excluded.reliability,
+                          confidence  = excluded.confidence,
+                          updated_at  = excluded.updated_at
+            """,
+            (source_id, market_id, new_reliability, new_confidence, now),
+        )
+
+        return ReliabilityRecord(
+            source_id=source_id,
+            market_id=market_id,
+            reliability=new_reliability,
+            confidence=new_confidence,
+            updated_at=now,
+        )
+
+    def list_sources(
+        self,
+        market_id: Optional[str] = None,
+    ) -> List[ReliabilityRecord]:
+        """Return all stored reliability records, optionally filtered by market.
+
+        Useful for diagnostics and admin tooling.
+        """
+        if market_id is not None:
+            rows = self._conn.execute(
+                "SELECT source_id, market_id, reliability, confidence, updated_at "
+                "FROM sources WHERE market_id = ? ORDER BY source_id",
+                (market_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT source_id, market_id, reliability, confidence, updated_at "
+                "FROM sources ORDER BY source_id, market_id",
+            ).fetchall()
+
+        return [
+            ReliabilityRecord(
+                source_id=r["source_id"],
+                market_id=r["market_id"],
+                reliability=r["reliability"],
+                confidence=r["confidence"],
+                updated_at=r["updated_at"],
+            )
+            for r in rows
+        ]
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Context manager support
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "SQLiteReliabilityStore":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_schema(self) -> None:
+        self._conn.executescript(_CREATE_TABLE_SQL)

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,248 @@
+"""Tests for SQLiteReliabilityStore."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bayesian_engine.reliability import (
+    DEFAULT_CONFIDENCE,
+    DEFAULT_RELIABILITY,
+    MAX_UPDATE_STEP,
+    ReliabilityRecord,
+    SQLiteReliabilityStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store() -> SQLiteReliabilityStore:
+    """In-memory store for fast unit tests."""
+    s = SQLiteReliabilityStore(":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def file_store(tmp_path: Path) -> SQLiteReliabilityStore:
+    """File-backed store for persistence integration tests."""
+    db_file = tmp_path / "reliability.db"
+    s = SQLiteReliabilityStore(db_file)
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Cold-start defaults
+# ---------------------------------------------------------------------------
+
+
+class TestColdStart:
+    def test_unseen_source_returns_defaults(self, store: SQLiteReliabilityStore) -> None:
+        rec = store.get_reliability("unknown-src", "market-1")
+        assert rec.source_id == "unknown-src"
+        assert rec.market_id == "market-1"
+        assert rec.reliability == DEFAULT_RELIABILITY
+        assert rec.confidence == DEFAULT_CONFIDENCE
+        assert rec.updated_at == ""  # never persisted
+
+    def test_cold_start_does_not_persist(self, store: SQLiteReliabilityStore) -> None:
+        """Calling get_reliability on an unseen source must NOT create a row."""
+        store.get_reliability("ghost", "market-1")
+        rows = store.list_sources()
+        assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# update_reliability
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateReliability:
+    def test_correct_outcome_increases_reliability(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        rec = store.update_reliability("src-a", "m-1", outcome_correct=True)
+        assert rec.reliability > DEFAULT_RELIABILITY
+
+    def test_incorrect_outcome_decreases_reliability(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        rec = store.update_reliability("src-a", "m-1", outcome_correct=False)
+        assert rec.reliability < DEFAULT_RELIABILITY
+
+    def test_update_step_never_exceeds_cap(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        rec = store.update_reliability("src-a", "m-1", outcome_correct=True)
+        delta = abs(rec.reliability - DEFAULT_RELIABILITY)
+        assert delta <= MAX_UPDATE_STEP + 1e-9  # float tolerance
+
+    def test_reliability_clamped_to_zero(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        """Reliability should never go below 0."""
+        # Drive reliability down many times
+        for _ in range(20):
+            store.update_reliability("low-src", "m-1", outcome_correct=False)
+        rec = store.get_reliability("low-src", "m-1")
+        assert rec.reliability >= 0.0
+
+    def test_reliability_clamped_to_one(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        """Reliability should never exceed 1."""
+        for _ in range(20):
+            store.update_reliability("high-src", "m-1", outcome_correct=True)
+        rec = store.get_reliability("high-src", "m-1")
+        assert rec.reliability <= 1.0
+
+    def test_confidence_grows_with_updates(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        rec1 = store.get_reliability("src-a", "m-1")
+
+        store.update_reliability("src-a", "m-1", outcome_correct=False)
+        rec2 = store.get_reliability("src-a", "m-1")
+
+        assert rec2.confidence > rec1.confidence
+
+    def test_update_persists_record(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        rec = store.get_reliability("src-a", "m-1")
+        assert rec.updated_at != ""
+        assert rec.reliability != DEFAULT_RELIABILITY
+
+    def test_multiple_updates_accumulate(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        r1 = store.get_reliability("src-a", "m-1").reliability
+
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        r2 = store.get_reliability("src-a", "m-1").reliability
+
+        assert r2 > r1
+
+    def test_per_market_isolation(
+        self, store: SQLiteReliabilityStore
+    ) -> None:
+        """Different markets maintain independent reliability scores."""
+        store.update_reliability("src-a", "market-1", outcome_correct=True)
+        store.update_reliability("src-a", "market-2", outcome_correct=False)
+
+        rec1 = store.get_reliability("src-a", "market-1")
+        rec2 = store.get_reliability("src-a", "market-2")
+
+        assert rec1.reliability > DEFAULT_RELIABILITY
+        assert rec2.reliability < DEFAULT_RELIABILITY
+
+
+# ---------------------------------------------------------------------------
+# list_sources
+# ---------------------------------------------------------------------------
+
+
+class TestListSources:
+    def test_empty_store_returns_empty(self, store: SQLiteReliabilityStore) -> None:
+        assert store.list_sources() == []
+
+    def test_lists_all_sources(self, store: SQLiteReliabilityStore) -> None:
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        store.update_reliability("src-b", "m-1", outcome_correct=False)
+
+        sources = store.list_sources()
+        assert len(sources) == 2
+        ids = {s.source_id for s in sources}
+        assert ids == {"src-a", "src-b"}
+
+    def test_filter_by_market(self, store: SQLiteReliabilityStore) -> None:
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        store.update_reliability("src-a", "m-2", outcome_correct=True)
+
+        m1 = store.list_sources(market_id="m-1")
+        assert len(m1) == 1
+        assert m1[0].market_id == "m-1"
+
+    def test_list_returns_sorted(self, store: SQLiteReliabilityStore) -> None:
+        store.update_reliability("src-c", "m-1", outcome_correct=True)
+        store.update_reliability("src-a", "m-1", outcome_correct=True)
+        store.update_reliability("src-b", "m-1", outcome_correct=True)
+
+        sources = store.list_sources()
+        ids = [s.source_id for s in sources]
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestContextManager:
+    def test_context_manager_closes(self, tmp_path: Path) -> None:
+        db_file = tmp_path / "ctx.db"
+        with SQLiteReliabilityStore(db_file) as store:
+            store.update_reliability("src-a", "m-1", outcome_correct=True)
+        # After exiting, the connection should be closed; opening again
+        # should still see the data.
+        with SQLiteReliabilityStore(db_file) as store2:
+            rec = store2.get_reliability("src-a", "m-1")
+            assert rec.reliability > DEFAULT_RELIABILITY
+
+
+# ---------------------------------------------------------------------------
+# Persistence (file-backed integration)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_data_survives_reconnect(self, tmp_path: Path) -> None:
+        db_file = tmp_path / "persist.db"
+
+        # Write
+        with SQLiteReliabilityStore(db_file) as store:
+            store.update_reliability("src-a", "m-1", outcome_correct=True)
+
+        # Read from fresh connection
+        with SQLiteReliabilityStore(db_file) as store2:
+            rec = store2.get_reliability("src-a", "m-1")
+            assert rec.reliability > DEFAULT_RELIABILITY
+            assert rec.confidence > DEFAULT_CONFIDENCE
+
+    def test_schema_created_on_new_db(self, tmp_path: Path) -> None:
+        db_file = tmp_path / "fresh.db"
+        with SQLiteReliabilityStore(db_file):
+            # Verify table exists
+            conn = sqlite3.connect(str(db_file))
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='sources'"
+            )
+            assert cursor.fetchone() is not None
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# ReliabilityRecord dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestReliabilityRecord:
+    def test_frozen(self) -> None:
+        rec = ReliabilityRecord("s", "m", 0.5, 0.5, "")
+        with pytest.raises(AttributeError):
+            rec.reliability = 0.9  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        a = ReliabilityRecord("s", "m", 0.5, 0.5, "t")
+        b = ReliabilityRecord("s", "m", 0.5, 0.5, "t")
+        assert a == b


### PR DESCRIPTION
## Summary

Implements persistent source reliability tracking via SQLite, as specified in issue #10.

### What's included

- **`SQLiteReliabilityStore`** class in `src/bayesian_engine/reliability.py`
  - SQLite-backed per-source, per-market reliability scores
  - Cold-start defaults: `reliability=0.5`, `confidence=0.5` (PRD spec)
  - Post-outcome Bayesian update with capped step (`max_update_step=0.10`)
  - `get_reliability(source_id, market_id)` — returns stored or cold-start defaults
  - `update_reliability(source_id, market_id, outcome_correct)` — Bayesian update with cap
  - `list_sources(market_id=None)` — diagnostics listing
  - Context manager support, WAL journal mode

- **Schema** (`sources` table):
  | Column | Type | Description |
  |---|---|---|
  | source_id | TEXT | Source identifier (PK part 1) |
  | market_id | TEXT | Market identifier (PK part 2) |
  | reliability | REAL | Score in [0, 1] |
  | confidence | REAL | Confidence in [0, 1] |
  | updated_at | TEXT | ISO-8601 UTC timestamp |

- **20 tests** in `tests/test_reliability.py` covering:
  - Cold-start defaults and non-persistence
  - Correct/incorrect outcome updates
  - Update cap enforcement
  - Boundary clamping (0 and 1)
  - Confidence growth
  - Per-market isolation
  - File-backed persistence across reconnects
  - Context manager lifecycle
  - Schema creation on fresh DB

- **Documentation** in `docs/reliability.md` with full schema and API reference

### CI

All 74 tests pass. Ruff and mypy clean.

Closes #10